### PR TITLE
Speed up the Python version of the program by a large factor

### DIFF
--- a/python/wooden-puzzle-solver.py
+++ b/python/wooden-puzzle-solver.py
@@ -29,7 +29,6 @@ def main():
     dingusS = Dingus([[0,0,0], [1,0,0], [1,1,0], [2,1,0]])
     dingusR = Dingus([[0,0,0], [0,1,0], [1,1,0]])
     dingi = [dingusL, dingusL, dingusL, dingusL, dingusT, dingusS, dingusR]
-    dingusrotations = []
 
     dingusrotations = [
         dingus.rotations
@@ -56,23 +55,23 @@ def main():
 
 
 def turn_the_crank(universe, dingusrotations, thread, threads):
-    if len(dingusrotations)==0:
+    if not dingusrotations:
         print 'We win!'
         print_universe(universe)
         return True
+
     for x in xrange(3):
         for y in xrange(3):
             for z in xrange(3):
-
                 if universe[x][y][z] != 0:
                     continue
+
                 for i in xrange(len(dingusrotations[0])):
-                    if len(dingusrotations)==7:
-                        if (i%threads != thread):
-                            continue
+                    if len(dingusrotations) == 7 and i % threads != thread:
+                        continue
 
                     olduniverse = copy.deepcopy(universe)
-                    if place_cubes(universe, dingusrotations[0][i], [x,y,z], 8-len(dingusrotations)):
+                    if place_cubes(universe, dingusrotations[0][i], [x,y,z], 8 - len(dingusrotations)):
                         turn_the_crank(copy.deepcopy(universe), dingusrotations[1:], thread, threads)
                     universe = olduniverse
 
@@ -118,15 +117,16 @@ def place_cubes(universe, cubes, origin, dingnum):
     d = copy.deepcopy(cubes)
     d = rel_to_abs(d, origin)
     for cube in d:
-
         for n in xrange(len(cube)):
             if (cube[n] > 2) or (cube[n] < 0):
                 return False
+
         if universe[cube[0]][cube[1]][cube[2]] != 0:
             return False
 
     for cube in d:
         universe[cube[0]][cube[1]][cube[2]] = dingnum
+
     return True
 
 
@@ -134,6 +134,7 @@ def rel_to_abs(cubes, origin):
     for cube in cubes:
         for n in xrange(len(cube)):
             cube[n] = cube[n] + origin[n]
+
     return cubes
 
 

--- a/python/wooden-puzzle-solver.py
+++ b/python/wooden-puzzle-solver.py
@@ -72,22 +72,22 @@ def turn_the_crank(universe, dingusrotations, thread, threads):
                             continue
 
                     olduniverse = copy.deepcopy(universe)
-                    if place_dingus(universe, dingusrotations[0][i], [x,y,z], 8-len(dingusrotations)):
+                    if place_cubes(universe, dingusrotations[0][i], [x,y,z], 8-len(dingusrotations)):
                         turn_the_crank(copy.deepcopy(universe), dingusrotations[1:], thread, threads)
                     universe = olduniverse
 
     return False
 
 
-def rotate_xy(dingus, rotnum):
+def rotate_xy(cubes, rotnum):
     if rotnum == 0:
-        return dingus
+        return cubes
     if rotnum == 1:
-        return [(lambda cube: [cube[1], -cube[0], cube[2]])(cube) for cube in dingus]
+        return [(lambda cube: [cube[1], -cube[0], cube[2]])(cube) for cube in cubes]
     if rotnum == 2:
-        return [(lambda cube: [-cube[0], -cube[1], cube[2]])(cube) for cube in dingus]
+        return [(lambda cube: [-cube[0], -cube[1], cube[2]])(cube) for cube in cubes]
     if rotnum == 3:
-        return [(lambda cube: [-cube[1], cube[0], cube[2]])(cube) for cube in dingus]
+        return [(lambda cube: [-cube[1], cube[0], cube[2]])(cube) for cube in cubes]
 
 
 def print_universe(universe):
@@ -99,23 +99,23 @@ def print_universe(universe):
         print
 
 
-def rotate_z(dingus, rotnum):
+def rotate_z(cubes, rotnum):
     if rotnum == 0:
-        return dingus
+        return cubes
     if rotnum == 1:
-        return [(lambda cube: [cube[0], cube[2], -cube[1]])(cube) for cube in dingus]
+        return [(lambda cube: [cube[0], cube[2], -cube[1]])(cube) for cube in cubes]
     if rotnum == 2:
-        return [(lambda cube: [cube[0], -cube[1], -cube[2]])(cube) for cube in dingus]
+        return [(lambda cube: [cube[0], -cube[1], -cube[2]])(cube) for cube in cubes]
     if rotnum == 3:
-        return [(lambda cube: [cube[0], -cube[2], cube[1]])(cube) for cube in dingus]
+        return [(lambda cube: [cube[0], -cube[2], cube[1]])(cube) for cube in cubes]
     if rotnum == 4:
-        return [(lambda cube: [-cube[2], cube[1], cube[0]])(cube) for cube in dingus]
+        return [(lambda cube: [-cube[2], cube[1], cube[0]])(cube) for cube in cubes]
     if rotnum == 5:
-        return [(lambda cube: [cube[2], cube[1], -cube[0]])(cube) for cube in dingus]
+        return [(lambda cube: [cube[2], cube[1], -cube[0]])(cube) for cube in cubes]
 
 
-def place_dingus(universe, dingus, origin, dingnum):
-    d = copy.deepcopy(dingus)
+def place_cubes(universe, cubes, origin, dingnum):
+    d = copy.deepcopy(cubes)
     d = rel_to_abs(d, origin)
     for cube in d:
 
@@ -130,11 +130,11 @@ def place_dingus(universe, dingus, origin, dingnum):
     return True
 
 
-def rel_to_abs(dingus, origin):
-    for cube in dingus:
+def rel_to_abs(cubes, origin):
+    for cube in cubes:
         for n in xrange(len(cube)):
             cube[n] = cube[n] + origin[n]
-    return dingus
+    return cubes
 
 
 if __name__ == '__main__':

--- a/python/wooden-puzzle-solver.py
+++ b/python/wooden-puzzle-solver.py
@@ -113,10 +113,19 @@ def rotate_z(cubes, rotnum):
         return [(lambda cube: [cube[2], cube[1], -cube[0]])(cube) for cube in cubes]
 
 
+def translate(cubes, origin):
+    return [
+        [
+            cube[n] + origin[n]
+            for n in xrange(len(cube))
+            ]
+        for cube in cubes
+        ]
+
+
 def place_cubes(universe, cubes, origin, dingnum):
-    d = copy.deepcopy(cubes)
-    d = rel_to_abs(d, origin)
-    for cube in d:
+    cubes = translate(cubes, origin)
+    for cube in cubes:
         for n in xrange(len(cube)):
             if (cube[n] > 2) or (cube[n] < 0):
                 return False
@@ -124,18 +133,10 @@ def place_cubes(universe, cubes, origin, dingnum):
         if universe[cube[0]][cube[1]][cube[2]] != 0:
             return False
 
-    for cube in d:
+    for cube in cubes:
         universe[cube[0]][cube[1]][cube[2]] = dingnum
 
     return True
-
-
-def rel_to_abs(cubes, origin):
-    for cube in cubes:
-        for n in xrange(len(cube)):
-            cube[n] = cube[n] + origin[n]
-
-    return cubes
 
 
 if __name__ == '__main__':

--- a/python/wooden-puzzle-solver.py
+++ b/python/wooden-puzzle-solver.py
@@ -105,22 +105,22 @@ def rotate_z(cubes, rotnum):
 
 
 def translate(cubes, origin):
-    return [
-        [
-            cube[n] + origin[n]
-            for n in xrange(len(cube))
-            ]
-        for cube in cubes
-        ]
+    newcubes = []
+    for cube in cubes:
+        newcube = [cube[i] + origin[i] for i in xrange(len(cube))]
+        if not all(0 <= coord < 3 for coord in newcube):
+            return None
+        newcubes.append(newcube)
+
+    return newcubes
 
 
 def place_cubes(universe, cubes, origin, dingnum):
     cubes = translate(cubes, origin)
-    for cube in cubes:
-        for n in xrange(len(cube)):
-            if (cube[n] > 2) or (cube[n] < 0):
-                return False
+    if not cubes:
+        return False
 
+    for cube in cubes:
         if universe[cube[0]][cube[1]][cube[2]] != 0:
             return False
 

--- a/python/wooden-puzzle-solver.py
+++ b/python/wooden-puzzle-solver.py
@@ -96,11 +96,10 @@ def turn_the_crank(universe, dingi, thread, threads):
         if len(dingi) == 7 and i % threads != thread:
             continue
 
-        olduniverse = copy.deepcopy(universe)
         if placeable(universe, dingi[0].placements[i]):
             place_cubes(universe, dingi[0].placements[i], 8 - len(dingi))
-            turn_the_crank(copy.deepcopy(universe), dingi[1:], thread, threads)
-        universe = olduniverse
+            turn_the_crank(universe, dingi[1:], thread, threads)
+            place_cubes(universe, dingi[0].placements[i], 0)
 
     return False
 

--- a/python/wooden-puzzle-solver.py
+++ b/python/wooden-puzzle-solver.py
@@ -141,10 +141,17 @@ def translate(cubes, origin):
     return newcubes
 
 
-def place_cubes(universe, cubes, dingnum):
+def placeable(universe, cubes):
     for cube in cubes:
         if universe[cube[0]][cube[1]][cube[2]] != 0:
             return False
+
+    return True
+
+
+def place_cubes(universe, cubes, dingnum):
+    if not placeable(universe, cubes):
+        return False
 
     for cube in cubes:
         universe[cube[0]][cube[1]][cube[2]] = dingnum

--- a/python/wooden-puzzle-solver.py
+++ b/python/wooden-puzzle-solver.py
@@ -38,13 +38,18 @@ def nodups(items):
 
 
 class Dingus:
-    def __init__(self, cubes):
+    def __init__(self, cubes, rotate=True):
         self.cubes = cubes
-        self.rotations = [
-            rotate_z(rotate_xy(self.cubes, n), m)
-            for m in xrange(6)
-            for n in xrange(4)
+
+        if rotate:
+            self.rotations = [
+                rotate_z(rotate_xy(self.cubes, n), m)
+                for m in xrange(6)
+                for n in xrange(4)
             ]
+        else:
+            self.rotations = [self.cubes]
+
         placements = [
             translate(rotation, (dx, dy, dz))
             for rotation in self.rotations
@@ -70,7 +75,7 @@ class Dingus:
 def main():
     dingusL = Dingus([(0,0,0), (1,0,0), (2,0,0), (2,1,0)])
     dingusT = Dingus([(0,0,0), (1,0,0), (1,1,0), (2,0,0)])
-    dingusS = Dingus([(0,0,0), (1,0,0), (1,1,0), (2,1,0)])
+    dingusS = Dingus([(0,0,0), (1,0,0), (1,1,0), (2,1,0)], rotate=False)
     dingusR = Dingus([(0,0,0), (0,1,0), (1,1,0)])
     dingi = [dingusL, dingusL, dingusL, dingusL, dingusT, dingusS, dingusR]
 

--- a/python/wooden-puzzle-solver.py
+++ b/python/wooden-puzzle-solver.py
@@ -30,11 +30,18 @@ def main():
     universe = instantiate_universe()
 
     if threads:
+        pids = []
         for j in xrange(threads):
-            if not os.fork():
+            pid = os.fork()
+            if pid:
+                pids.append(pid)
+            else:
                 turn_the_crank(universe, dingusrotations, j, threads)
-        while True:
-            os.wait()
+                return
+
+        for pid in pids:
+            os.waitpid(pid, 0)
+
     else:
         turn_the_crank(universe, dingusrotations, 0, 1)
 

--- a/python/wooden-puzzle-solver.py
+++ b/python/wooden-puzzle-solver.py
@@ -97,7 +97,8 @@ def turn_the_crank(universe, dingi, thread, threads):
             continue
 
         olduniverse = copy.deepcopy(universe)
-        if place_cubes(universe, dingi[0].placements[i], 8 - len(dingi)):
+        if placeable(universe, dingi[0].placements[i]):
+            place_cubes(universe, dingi[0].placements[i], 8 - len(dingi))
             turn_the_crank(copy.deepcopy(universe), dingi[1:], thread, threads)
         universe = olduniverse
 
@@ -150,13 +151,8 @@ def placeable(universe, cubes):
 
 
 def place_cubes(universe, cubes, dingnum):
-    if not placeable(universe, cubes):
-        return False
-
     for cube in cubes:
         universe[cube[0]][cube[1]][cube[2]] = dingnum
-
-    return True
 
 
 def print_universe(universe):

--- a/python/wooden-puzzle-solver.py
+++ b/python/wooden-puzzle-solver.py
@@ -22,7 +22,7 @@ class Dingus:
             for n in xrange(4)
             ]
         placements = [
-            translate(rotation, [dx, dy, dz])
+            translate(rotation, (dx, dy, dz))
             for rotation in self.rotations
             for dx in xrange(3)
             for dy in xrange(3)
@@ -36,10 +36,10 @@ class Dingus:
 
 
 def main():
-    dingusL = Dingus([[0,0,0], [1,0,0], [2,0,0], [2,1,0]])
-    dingusT = Dingus([[0,0,0], [1,0,0], [1,1,0], [2,0,0]])
-    dingusS = Dingus([[0,0,0], [1,0,0], [1,1,0], [2,1,0]])
-    dingusR = Dingus([[0,0,0], [0,1,0], [1,1,0]])
+    dingusL = Dingus([(0,0,0), (1,0,0), (2,0,0), (2,1,0)])
+    dingusT = Dingus([(0,0,0), (1,0,0), (1,1,0), (2,0,0)])
+    dingusS = Dingus([(0,0,0), (1,0,0), (1,1,0), (2,1,0)])
+    dingusR = Dingus([(0,0,0), (0,1,0), (1,1,0)])
     dingi = [dingusL, dingusL, dingusL, dingusL, dingusT, dingusS, dingusR]
 
     universe = instantiate_universe()
@@ -83,32 +83,32 @@ def rotate_xy(cubes, rotnum):
     if rotnum == 0:
         return cubes
     if rotnum == 1:
-        return [(lambda cube: [cube[1], -cube[0], cube[2]])(cube) for cube in cubes]
+        return tuple((lambda cube: [cube[1], -cube[0], cube[2]])(cube) for cube in cubes)
     if rotnum == 2:
-        return [(lambda cube: [-cube[0], -cube[1], cube[2]])(cube) for cube in cubes]
+        return tuple((lambda cube: [-cube[0], -cube[1], cube[2]])(cube) for cube in cubes)
     if rotnum == 3:
-        return [(lambda cube: [-cube[1], cube[0], cube[2]])(cube) for cube in cubes]
+        return tuple((lambda cube: [-cube[1], cube[0], cube[2]])(cube) for cube in cubes)
 
 
 def rotate_z(cubes, rotnum):
     if rotnum == 0:
         return cubes
     if rotnum == 1:
-        return [(lambda cube: [cube[0], cube[2], -cube[1]])(cube) for cube in cubes]
+        return tuple((lambda cube: [cube[0], cube[2], -cube[1]])(cube) for cube in cubes)
     if rotnum == 2:
-        return [(lambda cube: [cube[0], -cube[1], -cube[2]])(cube) for cube in cubes]
+        return tuple((lambda cube: [cube[0], -cube[1], -cube[2]])(cube) for cube in cubes)
     if rotnum == 3:
-        return [(lambda cube: [cube[0], -cube[2], cube[1]])(cube) for cube in cubes]
+        return tuple((lambda cube: [cube[0], -cube[2], cube[1]])(cube) for cube in cubes)
     if rotnum == 4:
-        return [(lambda cube: [-cube[2], cube[1], cube[0]])(cube) for cube in cubes]
+        return tuple((lambda cube: [-cube[2], cube[1], cube[0]])(cube) for cube in cubes)
     if rotnum == 5:
-        return [(lambda cube: [cube[2], cube[1], -cube[0]])(cube) for cube in cubes]
+        return tuple((lambda cube: [cube[2], cube[1], -cube[0]])(cube) for cube in cubes)
 
 
 def translate(cubes, origin):
     newcubes = []
     for cube in cubes:
-        newcube = [cube[i] + origin[i] for i in xrange(len(cube))]
+        newcube = tuple(cube[i] + origin[i] for i in xrange(len(cube)))
         if not all(0 <= coord < 3 for coord in newcube):
             return None
         newcubes.append(newcube)

--- a/python/wooden-puzzle-solver.py
+++ b/python/wooden-puzzle-solver.py
@@ -8,115 +8,115 @@ threads = multiprocessing.cpu_count()
 
 
 def instantiate_universe():
-	x = [0 for n in xrange(0,3)]
-	y = [copy.deepcopy(x) for n in xrange(0,3)]
-	return [copy.deepcopy(y) for n in xrange(0,3)]
-	
-	
+    x = [0 for n in xrange(0,3)]
+    y = [copy.deepcopy(x) for n in xrange(0,3)]
+    return [copy.deepcopy(y) for n in xrange(0,3)]
+
+
 def main():
-	dingusL = [[0,0,0], [1,0,0], [2,0,0], [2,1,0]]
-	dingusT = [[0,0,0], [1,0,0], [1,1,0], [2,0,0]]
-	dingusS = [[0,0,0], [1,0,0], [1,1,0], [2,1,0]]
-	dingusR = [[0,0,0], [0,1,0], [1,1,0]]
-	dingi = [dingusL, dingusL, dingusL, dingusL, dingusT, dingusS, dingusR]
-	dingusrotations = []
-	
-	for i in xrange(0,len(dingi)):
-		dingusrotations.append([])
-		for m in xrange(0,6):
-			for n in xrange(0,4):
-				dingusrotations[i].append(rotate_z(rotate_xy(dingi[i], n), m))
-	
-	universe = instantiate_universe()
-	
-	for j in xrange(0, threads):
-		if(not os.fork()):
-			turn_the_crank(universe, dingusrotations, j, threads)
-	while True:
-		os.wait()
+    dingusL = [[0,0,0], [1,0,0], [2,0,0], [2,1,0]]
+    dingusT = [[0,0,0], [1,0,0], [1,1,0], [2,0,0]]
+    dingusS = [[0,0,0], [1,0,0], [1,1,0], [2,1,0]]
+    dingusR = [[0,0,0], [0,1,0], [1,1,0]]
+    dingi = [dingusL, dingusL, dingusL, dingusL, dingusT, dingusS, dingusR]
+    dingusrotations = []
+
+    for i in xrange(0,len(dingi)):
+        dingusrotations.append([])
+        for m in xrange(0,6):
+            for n in xrange(0,4):
+                dingusrotations[i].append(rotate_z(rotate_xy(dingi[i], n), m))
+
+    universe = instantiate_universe()
+
+    for j in xrange(0, threads):
+        if(not os.fork()):
+            turn_the_crank(universe, dingusrotations, j, threads)
+    while True:
+        os.wait()
 
 
 def turn_the_crank(universe, dingusrotations, thread, threads):
-	if len(dingusrotations)==0:
-		print 'We win!'
-		print_universe(universe)
-		return True
-	for x in xrange(0,3):
-		for y in xrange(0,3):
-			for z in xrange(0,3):
+    if len(dingusrotations)==0:
+        print 'We win!'
+        print_universe(universe)
+        return True
+    for x in xrange(0,3):
+        for y in xrange(0,3):
+            for z in xrange(0,3):
 
-				if universe[x][y][z] != 0:
-					continue
-				for i in xrange(0, len(dingusrotations[0])):
-					if len(dingusrotations)==7:
-						if (i%threads != thread):
-							continue
-					
-					olduniverse = copy.deepcopy(universe)
-					if place_dingus(universe, dingusrotations[0][i], [x,y,z], 8-len(dingusrotations)):
-						turn_the_crank(copy.deepcopy(universe), dingusrotations[1:], thread, threads)
-					universe = olduniverse
-				
-	return False
+                if universe[x][y][z] != 0:
+                    continue
+                for i in xrange(0, len(dingusrotations[0])):
+                    if len(dingusrotations)==7:
+                        if (i%threads != thread):
+                            continue
+
+                    olduniverse = copy.deepcopy(universe)
+                    if place_dingus(universe, dingusrotations[0][i], [x,y,z], 8-len(dingusrotations)):
+                        turn_the_crank(copy.deepcopy(universe), dingusrotations[1:], thread, threads)
+                    universe = olduniverse
+
+    return False
 
 
-def rotate_xy(dingus, rotnum):	
-	if rotnum == 0:
-		return dingus
-	if rotnum == 1:
-		return [(lambda cube: [cube[1], -cube[0], cube[2]])(cube) for cube in dingus]
-	if rotnum == 2:
-		return [(lambda cube: [-cube[0], -cube[1], cube[2]])(cube) for cube in dingus]
-	if rotnum == 3:
-		return [(lambda cube: [-cube[1], cube[0], cube[2]])(cube) for cube in dingus]
+def rotate_xy(dingus, rotnum):
+    if rotnum == 0:
+        return dingus
+    if rotnum == 1:
+        return [(lambda cube: [cube[1], -cube[0], cube[2]])(cube) for cube in dingus]
+    if rotnum == 2:
+        return [(lambda cube: [-cube[0], -cube[1], cube[2]])(cube) for cube in dingus]
+    if rotnum == 3:
+        return [(lambda cube: [-cube[1], cube[0], cube[2]])(cube) for cube in dingus]
 
 
 def print_universe(universe):
-	for z in xrange(2,-1,-1):
-		for y in xrange(2,-1,-1):
-			for x in xrange(0,3):
-				print universe[x][y][z],
-			print
-		print
+    for z in xrange(2,-1,-1):
+        for y in xrange(2,-1,-1):
+            for x in xrange(0,3):
+                print universe[x][y][z],
+            print
+        print
 
 
 def rotate_z(dingus, rotnum):
-	if rotnum == 0:
-		return dingus
-	if rotnum == 1:
-		return [(lambda cube: [cube[0], cube[2], -cube[1]])(cube) for cube in dingus]
-	if rotnum == 2:
-		return [(lambda cube: [cube[0], -cube[1], -cube[2]])(cube) for cube in dingus]
-	if rotnum == 3:
-		return [(lambda cube: [cube[0], -cube[2], cube[1]])(cube) for cube in dingus]
-	if rotnum == 4:
-		return [(lambda cube: [-cube[2], cube[1], cube[0]])(cube) for cube in dingus]
-	if rotnum == 5:
-		return [(lambda cube: [cube[2], cube[1], -cube[0]])(cube) for cube in dingus]
+    if rotnum == 0:
+        return dingus
+    if rotnum == 1:
+        return [(lambda cube: [cube[0], cube[2], -cube[1]])(cube) for cube in dingus]
+    if rotnum == 2:
+        return [(lambda cube: [cube[0], -cube[1], -cube[2]])(cube) for cube in dingus]
+    if rotnum == 3:
+        return [(lambda cube: [cube[0], -cube[2], cube[1]])(cube) for cube in dingus]
+    if rotnum == 4:
+        return [(lambda cube: [-cube[2], cube[1], cube[0]])(cube) for cube in dingus]
+    if rotnum == 5:
+        return [(lambda cube: [cube[2], cube[1], -cube[0]])(cube) for cube in dingus]
 
 
 def place_dingus(universe, dingus, origin, dingnum):
-	d = copy.deepcopy(dingus)
-	d = rel_to_abs(d, origin)
-	for cube in d:
+    d = copy.deepcopy(dingus)
+    d = rel_to_abs(d, origin)
+    for cube in d:
 
-		for n in xrange(0,len(cube)):
-			if (cube[n] > 2) or (cube[n] < 0):
-				return False			
-		if universe[cube[0]][cube[1]][cube[2]] != 0:
-			return False
+        for n in xrange(0,len(cube)):
+            if (cube[n] > 2) or (cube[n] < 0):
+                return False
+        if universe[cube[0]][cube[1]][cube[2]] != 0:
+            return False
 
-	for cube in d:
-		universe[cube[0]][cube[1]][cube[2]] = dingnum
-	return True
+    for cube in d:
+        universe[cube[0]][cube[1]][cube[2]] = dingnum
+    return True
 
 
 def rel_to_abs(dingus, origin):
-	for cube in dingus:
-		for n in xrange(0,len(cube)):
-			cube[n] = cube[n] + origin[n]
-	return dingus
+    for cube in dingus:
+        for n in xrange(0,len(cube)):
+            cube[n] = cube[n] + origin[n]
+    return dingus
 
 
 if __name__ == '__main__':
-	main()
+    main()

--- a/python/wooden-puzzle-solver.py
+++ b/python/wooden-puzzle-solver.py
@@ -13,19 +13,28 @@ def instantiate_universe():
     return [copy.deepcopy(y) for n in xrange(3)]
 
 
+class Dingus:
+    def __init__(self, cubes):
+        self.cubes = cubes
+        self.rotations = [
+            rotate_z(rotate_xy(self.cubes, n), m)
+            for m in xrange(6)
+            for n in xrange(4)
+            ]
+
+
 def main():
-    dingusL = [[0,0,0], [1,0,0], [2,0,0], [2,1,0]]
-    dingusT = [[0,0,0], [1,0,0], [1,1,0], [2,0,0]]
-    dingusS = [[0,0,0], [1,0,0], [1,1,0], [2,1,0]]
-    dingusR = [[0,0,0], [0,1,0], [1,1,0]]
+    dingusL = Dingus([[0,0,0], [1,0,0], [2,0,0], [2,1,0]])
+    dingusT = Dingus([[0,0,0], [1,0,0], [1,1,0], [2,0,0]])
+    dingusS = Dingus([[0,0,0], [1,0,0], [1,1,0], [2,1,0]])
+    dingusR = Dingus([[0,0,0], [0,1,0], [1,1,0]])
     dingi = [dingusL, dingusL, dingusL, dingusL, dingusT, dingusS, dingusR]
     dingusrotations = []
 
-    for i in xrange(len(dingi)):
-        dingusrotations.append([])
-        for m in xrange(6):
-            for n in xrange(4):
-                dingusrotations[i].append(rotate_z(rotate_xy(dingi[i], n), m))
+    dingusrotations = [
+        dingus.rotations
+        for dingus in dingi
+        ]
 
     universe = instantiate_universe()
 

--- a/python/wooden-puzzle-solver.py
+++ b/python/wooden-puzzle-solver.py
@@ -8,9 +8,9 @@ threads = multiprocessing.cpu_count()
 
 
 def instantiate_universe():
-    x = [0 for n in xrange(0,3)]
-    y = [copy.deepcopy(x) for n in xrange(0,3)]
-    return [copy.deepcopy(y) for n in xrange(0,3)]
+    x = [0 for n in xrange(3)]
+    y = [copy.deepcopy(x) for n in xrange(3)]
+    return [copy.deepcopy(y) for n in xrange(3)]
 
 
 def main():
@@ -21,15 +21,15 @@ def main():
     dingi = [dingusL, dingusL, dingusL, dingusL, dingusT, dingusS, dingusR]
     dingusrotations = []
 
-    for i in xrange(0,len(dingi)):
+    for i in xrange(len(dingi)):
         dingusrotations.append([])
-        for m in xrange(0,6):
-            for n in xrange(0,4):
+        for m in xrange(6):
+            for n in xrange(4):
                 dingusrotations[i].append(rotate_z(rotate_xy(dingi[i], n), m))
 
     universe = instantiate_universe()
 
-    for j in xrange(0, threads):
+    for j in xrange(threads):
         if(not os.fork()):
             turn_the_crank(universe, dingusrotations, j, threads)
     while True:
@@ -41,13 +41,13 @@ def turn_the_crank(universe, dingusrotations, thread, threads):
         print 'We win!'
         print_universe(universe)
         return True
-    for x in xrange(0,3):
-        for y in xrange(0,3):
-            for z in xrange(0,3):
+    for x in xrange(3):
+        for y in xrange(3):
+            for z in xrange(3):
 
                 if universe[x][y][z] != 0:
                     continue
-                for i in xrange(0, len(dingusrotations[0])):
+                for i in xrange(len(dingusrotations[0])):
                     if len(dingusrotations)==7:
                         if (i%threads != thread):
                             continue
@@ -74,7 +74,7 @@ def rotate_xy(dingus, rotnum):
 def print_universe(universe):
     for z in xrange(2,-1,-1):
         for y in xrange(2,-1,-1):
-            for x in xrange(0,3):
+            for x in xrange(3):
                 print universe[x][y][z],
             print
         print
@@ -100,7 +100,7 @@ def place_dingus(universe, dingus, origin, dingnum):
     d = rel_to_abs(d, origin)
     for cube in d:
 
-        for n in xrange(0,len(cube)):
+        for n in xrange(len(cube)):
             if (cube[n] > 2) or (cube[n] < 0):
                 return False
         if universe[cube[0]][cube[1]][cube[2]] != 0:
@@ -113,7 +113,7 @@ def place_dingus(universe, dingus, origin, dingnum):
 
 def rel_to_abs(dingus, origin):
     for cube in dingus:
-        for n in xrange(0,len(cube)):
+        for n in xrange(len(cube)):
             cube[n] = cube[n] + origin[n]
     return dingus
 

--- a/python/wooden-puzzle-solver.py
+++ b/python/wooden-puzzle-solver.py
@@ -89,15 +89,6 @@ def rotate_xy(cubes, rotnum):
         return [(lambda cube: [-cube[1], cube[0], cube[2]])(cube) for cube in cubes]
 
 
-def print_universe(universe):
-    for z in xrange(2,-1,-1):
-        for y in xrange(2,-1,-1):
-            for x in xrange(3):
-                print universe[x][y][z],
-            print
-        print
-
-
 def rotate_z(cubes, rotnum):
     if rotnum == 0:
         return cubes
@@ -137,6 +128,15 @@ def place_cubes(universe, cubes, origin, dingnum):
         universe[cube[0]][cube[1]][cube[2]] = dingnum
 
     return True
+
+
+def print_universe(universe):
+    for z in xrange(2,-1,-1):
+        for y in xrange(2,-1,-1):
+            for x in xrange(3):
+                print universe[x][y][z],
+            print
+        print
 
 
 if __name__ == '__main__':

--- a/python/wooden-puzzle-solver.py
+++ b/python/wooden-puzzle-solver.py
@@ -38,7 +38,8 @@ def nodups(items):
 
 
 class Dingus:
-    def __init__(self, cubes, rotate=True):
+    def __init__(self, name, cubes, rotate=True):
+        self.name = name
         self.cubes = cubes
 
         if rotate:
@@ -47,8 +48,10 @@ class Dingus:
                 for m in xrange(6)
                 for n in xrange(4)
             ]
+            sys.stderr.write("Dingus %s: found %d rotations\n" % (self.name, len(self.rotations),))
         else:
             self.rotations = [self.cubes]
+            sys.stderr.write("Dingus %s: ignoring rotations\n" % (self.name,))
 
         placements = [
             translate(rotation, (dx, dy, dz))
@@ -71,12 +74,14 @@ class Dingus:
         for placement in placements:
             self.fillers[placement[0]].append(placement)
 
+        sys.stderr.write("          found %d placements\n" % (len(self.placements),))
+
 
 def main():
-    dingusL = Dingus([(0,0,0), (1,0,0), (2,0,0), (2,1,0)])
-    dingusT = Dingus([(0,0,0), (1,0,0), (1,1,0), (2,0,0)])
-    dingusS = Dingus([(0,0,0), (1,0,0), (1,1,0), (2,1,0)], rotate=False)
-    dingusR = Dingus([(0,0,0), (0,1,0), (1,1,0)])
+    dingusL = Dingus("L", [(0,0,0), (1,0,0), (2,0,0), (2,1,0)])
+    dingusT = Dingus("T", [(0,0,0), (1,0,0), (1,1,0), (2,0,0)])
+    dingusS = Dingus("S", [(0,0,0), (1,0,0), (1,1,0), (2,1,0)], rotate=False)
+    dingusR = Dingus("R", [(0,0,0), (0,1,0), (1,1,0)])
     dingi = [dingusL, dingusL, dingusL, dingusL, dingusT, dingusS, dingusR]
 
     universe = instantiate_universe()

--- a/python/wooden-puzzle-solver.py
+++ b/python/wooden-puzzle-solver.py
@@ -30,11 +30,6 @@ def main():
     dingusR = Dingus([[0,0,0], [0,1,0], [1,1,0]])
     dingi = [dingusL, dingusL, dingusL, dingusL, dingusT, dingusS, dingusR]
 
-    dingusrotations = [
-        dingus.rotations
-        for dingus in dingi
-        ]
-
     universe = instantiate_universe()
 
     if threads:
@@ -44,18 +39,18 @@ def main():
             if pid:
                 pids.append(pid)
             else:
-                turn_the_crank(universe, dingusrotations, j, threads)
+                turn_the_crank(universe, dingi, j, threads)
                 return
 
         for pid in pids:
             os.waitpid(pid, 0)
 
     else:
-        turn_the_crank(universe, dingusrotations, 0, 1)
+        turn_the_crank(universe, dingi, 0, 1)
 
 
-def turn_the_crank(universe, dingusrotations, thread, threads):
-    if not dingusrotations:
+def turn_the_crank(universe, dingi, thread, threads):
+    if not dingi:
         print 'We win!'
         print_universe(universe)
         return True
@@ -66,13 +61,13 @@ def turn_the_crank(universe, dingusrotations, thread, threads):
                 if universe[x][y][z] != 0:
                     continue
 
-                for i in xrange(len(dingusrotations[0])):
-                    if len(dingusrotations) == 7 and i % threads != thread:
+                for i in xrange(len(dingi[0].rotations)):
+                    if len(dingi) == 7 and i % threads != thread:
                         continue
 
                     olduniverse = copy.deepcopy(universe)
-                    if place_cubes(universe, dingusrotations[0][i], [x,y,z], 8 - len(dingusrotations)):
-                        turn_the_crank(copy.deepcopy(universe), dingusrotations[1:], thread, threads)
+                    if place_cubes(universe, dingi[0].rotations[i], [x,y,z], 8 - len(dingi)):
+                        turn_the_crank(copy.deepcopy(universe), dingi[1:], thread, threads)
                     universe = olduniverse
 
     return False

--- a/python/wooden-puzzle-solver.py
+++ b/python/wooden-puzzle-solver.py
@@ -29,11 +29,14 @@ def main():
 
     universe = instantiate_universe()
 
-    for j in xrange(threads):
-        if(not os.fork()):
-            turn_the_crank(universe, dingusrotations, j, threads)
-    while True:
-        os.wait()
+    if threads:
+        for j in xrange(threads):
+            if not os.fork():
+                turn_the_crank(universe, dingusrotations, j, threads)
+        while True:
+            os.wait()
+    else:
+        turn_the_crank(universe, dingusrotations, 0, 1)
 
 
 def turn_the_crank(universe, dingusrotations, thread, threads):

--- a/python/wooden-puzzle-solver.py
+++ b/python/wooden-puzzle-solver.py
@@ -115,13 +115,16 @@ def fill(universe, dingi, thread, threads, to_fill=None):
         # among dingus.fillers[space] because any other positions of a
         # dingus would protrude into the spaces that we have already
         # filled.
+        last = None
         for i in range(len(dingi)):
             dingus = dingi.pop(i)
-            for placement in dingus.fillers[space]:
-                if placeable(universe, placement):
-                    place_cubes(universe, placement, 8 - len(dingi))
-                    fill(universe, dingi, thread, threads, to_fill)
-                    place_cubes(universe, placement, 0)
+            if dingus != last:
+                for placement in dingus.fillers[space]:
+                    if placeable(universe, placement):
+                        place_cubes(universe, placement, 8 - len(dingi))
+                        fill(universe, dingi, thread, threads, to_fill)
+                        place_cubes(universe, placement, 0)
+                last = dingus
             dingi.insert(i, dingus)
     to_fill.append(space)
 

--- a/python/wooden-puzzle-solver.py
+++ b/python/wooden-puzzle-solver.py
@@ -21,6 +21,18 @@ class Dingus:
             for m in xrange(6)
             for n in xrange(4)
             ]
+        placements = [
+            translate(rotation, [dx, dy, dz])
+            for rotation in self.rotations
+            for dx in xrange(3)
+            for dy in xrange(3)
+            for dz in xrange(3)
+            ]
+        self.placements = [
+            cubes
+            for cubes in placements
+            if cubes is not None
+            ]
 
 
 def main():
@@ -55,20 +67,14 @@ def turn_the_crank(universe, dingi, thread, threads):
         print_universe(universe)
         return True
 
-    for x in xrange(3):
-        for y in xrange(3):
-            for z in xrange(3):
-                if universe[x][y][z] != 0:
-                    continue
+    for i in xrange(len(dingi[0].placements)):
+        if len(dingi) == 7 and i % threads != thread:
+            continue
 
-                for i in xrange(len(dingi[0].rotations)):
-                    if len(dingi) == 7 and i % threads != thread:
-                        continue
-
-                    olduniverse = copy.deepcopy(universe)
-                    if place_cubes(universe, dingi[0].rotations[i], [x,y,z], 8 - len(dingi)):
-                        turn_the_crank(copy.deepcopy(universe), dingi[1:], thread, threads)
-                    universe = olduniverse
+        olduniverse = copy.deepcopy(universe)
+        if place_cubes(universe, dingi[0].placements[i], 8 - len(dingi)):
+            turn_the_crank(copy.deepcopy(universe), dingi[1:], thread, threads)
+        universe = olduniverse
 
     return False
 
@@ -110,11 +116,7 @@ def translate(cubes, origin):
     return newcubes
 
 
-def place_cubes(universe, cubes, origin, dingnum):
-    cubes = translate(cubes, origin)
-    if not cubes:
-        return False
-
+def place_cubes(universe, cubes, dingnum):
     for cube in cubes:
         if universe[cube[0]][cube[1]][cube[2]] != 0:
             return False

--- a/python/wooden-puzzle-solver.py
+++ b/python/wooden-puzzle-solver.py
@@ -7,10 +7,34 @@ import multiprocessing
 threads = multiprocessing.cpu_count()
 
 
+SPACES = [
+    (x,y,z)
+    for x in range(3)
+    for y in range(3)
+    for z in range(3)
+    ]
+
+
 def instantiate_universe():
     x = [0 for n in xrange(3)]
     y = [copy.deepcopy(x) for n in xrange(3)]
     return [copy.deepcopy(y) for n in xrange(3)]
+
+
+def nodups(items):
+    items = iter(items)
+    try:
+        last = items.next()
+        yield last
+        while True:
+            item = items.next()
+            if item == last:
+                continue
+            else:
+                yield item
+                last = item
+    except StopIteration:
+        return
 
 
 class Dingus:
@@ -28,11 +52,12 @@ class Dingus:
             for dy in xrange(3)
             for dz in xrange(3)
             ]
-        self.placements = [
-            cubes
+        placements = sorted(
+            sorted(cubes)
             for cubes in placements
             if cubes is not None
-            ]
+            )
+        self.placements = list(nodups(placements))
 
 
 def main():


### PR DESCRIPTION
You nerd-sniped me. This branch speeds up the Python version by some large but unknown factor. The factor is unknown because I never had the patience to run the original version to completion. But now it runs in about 4 s, single-threaded.

Changes:

* Pre-compute all possible placements (rotations and translations) of each dingus
    * Pre-discard any placements that protrude out of the 3×3×3 box.
    * Only include unique placements (the dinguses have symmetries, so some rotation/translation combinations end up with cubes in the same places).
    This dramatically reduces the number of placements that have to be considered, plus it reduces the amount of work that has to be done to test each placement (the dingus doesn't have to be re-translated each time).
* Don't copy the universe for each attempt. Instead, remove the piece from the board as we backtrack. I didn't check whether this significantly affects performance.
* Fill spaces in order. This has two advantages:
    * If a space can't be filled, that fact is discovered earlier so we can abandon that line of attack.
    * Since we know that all spaces "preceding" the current space are filled, we only have to try dingus placements whose "earliest" cube is in the space that we are currently trying to fill.
* Treat all same-shaped dingi as indistinguishable. E.g., once we see that on "L" piece fits in a certain position, there is no need to try other "L" pieces in the same position because the solution would be equivalent. Similarly, if one "L" piece *doesn't* fit, there is no need to try the other "L" pieces in the same place. Since there are 4 "L" dingi, this reduces the problem space by a factor of 4!=24.
* A cube has 48-fold symmetry including reflection. There is no need to produce 48 versions of each solution. So remove most of the symmetries by not allowing `dingusS` to rotate.

If I were motivated to speed this up even more, I would introduce a new representation of the world: treat each of the 27 spaces in the cube as a bit in an integer, and each dingus placement as the integer with the bits that it covers set to 1. This would reduce the cost of checking whether a dingus placement can be used to a few binary operations. However, it would complicate the code required to print out solutions, so I didn't bother.

Thanks for a fun challenge!
