### PR TITLE
Python and Go: Filter noncanonical solutions

### DIFF
--- a/go/wooden-puzzle-solver.go
+++ b/go/wooden-puzzle-solver.go
@@ -349,6 +349,61 @@ func (w *World) Print(f *bufio.Writer) {
 	f.WriteByte('\n')
 }
 
+func (w *World) Key() [27]byte {
+	var key [27]byte
+	var index int
+	for z := 0; z < 3; z++ {
+		for y := 0; y < 3; y++ {
+			for x := 0; x < 3; x++ {
+				key[index] = w[x][y][z]
+				index++
+			}
+		}
+	}
+	return key
+}
+
+func (w *World) RotateWorld(xyRot, zRot CubeRotation) World {
+	var rotated World
+	for x := 0; x < 3; x++ {
+		for y := 0; y < 3; y++ {
+			for z := 0; z < 3; z++ {
+				c := Cube{Coord(x) - 1, Coord(y) - 1, Coord(z) - 1}
+				rc := xyRot(c)
+				rc = zRot(rc)
+				rx, ry, rz := int(rc.x)+1, int(rc.y)+1, int(rc.z)+1
+				rotated[rx][ry][rz] = w[x][y][z]
+			}
+		}
+	}
+	return rotated
+}
+
+func keyLess(a, b [27]byte) bool {
+	for i := range a {
+		if a[i] != b[i] {
+			return a[i] < b[i]
+		}
+	}
+	return false
+}
+
+func (w *World) IsCanonical() bool {
+	canonicalKey := w.Key()
+	for i, zRot := range ZRotations {
+		for j, xyRot := range XYRotations {
+			if i == 0 && j == 0 {
+				continue // skip identity
+			}
+			rotated := w.RotateWorld(xyRot, zRot)
+			if keyLess(rotated.Key(), canonicalKey) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 func (w *World) Fill(dingi []*Dingus, toFill []Position, c byte, solutions chan<- World) {
 	// Find the next position that needs filling:
 	var p Position
@@ -403,8 +458,10 @@ func main() {
 	var count int
 	f := bufio.NewWriter(os.Stdout)
 	for w := range solutions {
-		w.Print(f)
-		count++
+		if w.IsCanonical() {
+			w.Print(f)
+			count++
+		}
 	}
 	f.Flush()
 	fmt.Fprintf(os.Stderr, "Found %d solutions\n", count)

--- a/go/wooden-puzzle-solver_test.go
+++ b/go/wooden-puzzle-solver_test.go
@@ -73,6 +73,58 @@ func TestFitsPlaceAndUnplace(t *testing.T) {
 	}
 }
 
+func TestSolverProduces415CanonicalSolutions(t *testing.T) {
+	var world World
+	DingusL := NewDingus(&world, "L", true, CubeList{{0, 0, 0}, {1, 0, 0}, {2, 0, 0}, {2, 1, 0}})
+	DingusT := NewDingus(&world, "T", true, CubeList{{0, 0, 0}, {1, 0, 0}, {1, 1, 0}, {2, 0, 0}})
+	DingusS := NewDingus(&world, "S", false, CubeList{{0, 0, 0}, {1, 0, 0}, {1, 1, 0}, {2, 1, 0}})
+	DingusR := NewDingus(&world, "R", true, CubeList{{0, 0, 0}, {0, 1, 0}, {1, 1, 0}})
+	Dingi := []*Dingus{&DingusL, &DingusL, &DingusL, &DingusL, &DingusT, &DingusS, &DingusR}
+
+	solutions := make(chan World)
+	go func() {
+		world.Fill(Dingi, AllPositions, '1', solutions)
+		close(solutions)
+	}()
+
+	var count int
+	for w := range solutions {
+		if !w.IsCanonical() {
+			continue
+		}
+		// Validate every cell is filled with piece number '1'..'7'
+		for x := 0; x < 3; x++ {
+			for y := 0; y < 3; y++ {
+				for z := 0; z < 3; z++ {
+					v := w[x][y][z]
+					if v < '1' || v > '7' {
+						t.Fatalf("solution %d: unexpected value %c at (%d,%d,%d)", count, v, x, y, z)
+					}
+				}
+			}
+		}
+		// Validate all 7 pieces present
+		var present [8]bool
+		for x := 0; x < 3; x++ {
+			for y := 0; y < 3; y++ {
+				for z := 0; z < 3; z++ {
+					present[w[x][y][z]-'0'] = true
+				}
+			}
+		}
+		for p := 1; p <= 7; p++ {
+			if !present[p] {
+				t.Fatalf("solution %d: missing piece %d", count, p)
+			}
+		}
+		count++
+	}
+
+	if count != 415 {
+		t.Fatalf("expected 415 canonical solutions, got %d", count)
+	}
+}
+
 func TestWorldPrintIncludesExpectedCharacters(t *testing.T) {
 	var w World
 	w.Place(CubeList{{0, 0, 0}}, '1')

--- a/python/tests/test_wooden_puzzle_solver.py
+++ b/python/tests/test_wooden_puzzle_solver.py
@@ -62,7 +62,7 @@ class WoodenPuzzleSolverTests(unittest.TestCase):
         self.assertEqual(len(dingus.rotations), 1)
         self.assertGreater(len(dingus.placements), 0)
 
-    def test_fill_emits_expected_solution_format_without_search(self):
+    def test_print_universe_format(self):
         universe = solver.instantiate_universe()
         for x in range(3):
             for y in range(3):
@@ -71,7 +71,7 @@ class WoodenPuzzleSolverTests(unittest.TestCase):
 
         output = io.StringIO()
         with redirect_stdout(output):
-            solver.fill(universe, [], 0, 1, to_fill=[])
+            solver.print_universe(universe)
 
         non_empty_lines = [line for line in output.getvalue().splitlines() if line.strip()]
         self.assertEqual(len(non_empty_lines), 3)
@@ -84,6 +84,102 @@ class WoodenPuzzleSolverTests(unittest.TestCase):
         for row_index, line in enumerate(non_empty_lines):
             values = [int(token) for token in line.split()]
             self.assertEqual(values, expected_rows[row_index])
+
+    def test_is_canonical_exactly_one_rotation_is_canonical(self):
+        # Fill universe with distinct values and find the canonical rotation.
+        universe = solver.instantiate_universe()
+        val = 1
+        for x in range(3):
+            for y in range(3):
+                for z in range(3):
+                    universe[x][y][z] = val
+                    val += 1
+
+        # Exactly one of the 24 rotations should be canonical.
+        canonical_count = 0
+        for z_rot in range(6):
+            for xy_rot in range(4):
+                rotated = solver.rotate_world(universe, xy_rot, z_rot)
+                if solver.is_canonical(rotated):
+                    canonical_count += 1
+        self.assertEqual(canonical_count, 1)
+
+    def test_is_canonical_rejects_non_canonical(self):
+        # Find a canonical orientation, then rotate it and confirm rejection.
+        universe = solver.instantiate_universe()
+        val = 1
+        for x in range(3):
+            for y in range(3):
+                for z in range(3):
+                    universe[x][y][z] = val
+                    val += 1
+
+        # Find the canonical rotation first.
+        canonical = None
+        for z_rot in range(6):
+            for xy_rot in range(4):
+                rotated = solver.rotate_world(universe, xy_rot, z_rot)
+                if solver.is_canonical(rotated):
+                    canonical = rotated
+                    break
+            if canonical:
+                break
+
+        # Rotate the canonical universe; the result should not be canonical.
+        rotated = solver.rotate_world(canonical, 1, 0)
+        self.assertFalse(solver.is_canonical(rotated))
+
+    def test_rotate_world_round_trip(self):
+        universe = solver.instantiate_universe()
+        val = 1
+        for x in range(3):
+            for y in range(3):
+                for z in range(3):
+                    universe[x][y][z] = val
+                    val += 1
+        # Four quarter-turns in xy should return to original.
+        u = universe
+        for _ in range(4):
+            u = solver.rotate_world(u, 1, 0)
+        self.assertEqual(solver.universe_key(u), solver.universe_key(universe))
+
+    def test_dingus_rotation_counts(self):
+        # Known rotation counts for each piece shape.
+        dingusL = solver.Dingus("L", [(0,0,0), (1,0,0), (2,0,0), (2,1,0)])
+        dingusT = solver.Dingus("T", [(0,0,0), (1,0,0), (1,1,0), (2,0,0)])
+        dingusR = solver.Dingus("R", [(0,0,0), (0,1,0), (1,1,0)])
+        dingusS = solver.Dingus("S", [(0,0,0), (1,0,0), (1,1,0), (2,1,0)], rotate=False)
+        self.assertEqual(len(dingusL.rotations), 24)
+        self.assertEqual(len(dingusT.rotations), 12)
+        self.assertEqual(len(dingusR.rotations), 12)
+        self.assertEqual(len(dingusS.rotations), 1)
+
+    def test_solver_finds_415_canonical_solutions(self):
+        """Run the full solver and verify it finds exactly 415 canonical solutions."""
+        dingusL = solver.Dingus("L", [(0,0,0), (1,0,0), (2,0,0), (2,1,0)])
+        dingusT = solver.Dingus("T", [(0,0,0), (1,0,0), (1,1,0), (2,0,0)])
+        dingusS = solver.Dingus("S", [(0,0,0), (1,0,0), (1,1,0), (2,1,0)], rotate=False)
+        dingusR = solver.Dingus("R", [(0,0,0), (0,1,0), (1,1,0)])
+        dingi = [dingusL, dingusL, dingusL, dingusL, dingusT, dingusS, dingusR]
+
+        universe = solver.instantiate_universe()
+        output = io.StringIO()
+        with redirect_stdout(output):
+            count = solver.fill(universe, dingi)
+
+        self.assertEqual(count, 415)
+
+        # Each solution is 3 non-empty lines followed by 1 blank line.
+        lines = output.getvalue().splitlines()
+        non_empty = [l for l in lines if l.strip()]
+        self.assertEqual(len(non_empty), 415 * 3)
+
+        # Verify each solution row has exactly 9 values (3 slices x 3 columns).
+        for line in non_empty:
+            values = line.split()
+            self.assertEqual(len(values), 9)
+            for v in values:
+                self.assertIn(int(v), range(1, 8))
 
 
 if __name__ == "__main__":

--- a/python/wooden-puzzle-solver.py
+++ b/python/wooden-puzzle-solver.py
@@ -4,9 +4,6 @@ import os
 import sys
 import multiprocessing
 
-#threads = multiprocessing.cpu_count()
-threads = None
-
 SPACES = [
     (x,y,z)
     for x in range(3)
@@ -91,40 +88,32 @@ def main():
     dingi = [dingusL, dingusL, dingusL, dingusL, dingusT, dingusS, dingusR]
 
     universe = instantiate_universe()
+    count = 0
 
-    if threads:
-        pids = []
-        for j in range(threads):
-            pid = os.fork()
-            if pid:
-                pids.append(pid)
-            else:
-                fill(universe, dingi, j, threads)
-                return
-
-        for pid in pids:
-            os.waitpid(pid, 0)
-
-    else:
-        fill(universe, dingi, 0, 1)
+    count += fill(universe, dingi)
+    sys.stderr.write("Found %d solutions\n" % count)
 
 
-def fill(universe, dingi, thread, threads, to_fill=None):
+def fill(universe, dingi, to_fill=None):
     """Try to fill universe.
 
     Try to fill universe given that all spaces not in the `empty` list have
     already been filled."""
 
+    count = 0
+
     if to_fill is None:
         to_fill = list(reversed(SPACES))
     elif not to_fill:
-        print_universe(universe)
-        return
+        if is_canonical(universe):
+            print_universe(universe)
+            count += 1
+        return count
 
     space = to_fill.pop()
     if universe[space[0]][space[1]][space[2]] != 0:
         # Space is already filled; continue to the next space:
-        fill(universe, dingi, thread, threads, to_fill)
+        count += fill(universe, dingi, to_fill)
     else:
         # Find a dingus that can fill space. We only need to look
         # among dingus.fillers[space] because any other positions of a
@@ -137,11 +126,12 @@ def fill(universe, dingi, thread, threads, to_fill=None):
                 for placement in dingus.fillers[space]:
                     if placeable(universe, placement):
                         place_cubes(universe, placement, 7 - len(dingi))
-                        fill(universe, dingi, thread, threads, to_fill)
+                        count += fill(universe, dingi, to_fill)
                         place_cubes(universe, placement, 0)
                 last = dingus
             dingi.insert(i, dingus)
     to_fill.append(space)
+    return count
 
 
 def rotate_xy(cubes, rotnum):
@@ -197,6 +187,65 @@ def placeable(universe, cubes):
 def place_cubes(universe, cubes, dingnum):
     for cube in cubes:
         universe[cube[0]][cube[1]][cube[2]] = dingnum
+
+
+def rotate_coord_xy(x, y, z, n):
+    if n == 0:
+        return (x, y, z)
+    if n == 1:
+        return (y, -x, z)
+    if n == 2:
+        return (-x, -y, z)
+    if n == 3:
+        return (-y, x, z)
+
+
+def rotate_coord_z(x, y, z, n):
+    if n == 0:
+        return (x, y, z)
+    if n == 1:
+        return (x, z, -y)
+    if n == 2:
+        return (x, -y, -z)
+    if n == 3:
+        return (x, -z, y)
+    if n == 4:
+        return (-z, y, x)
+    if n == 5:
+        return (z, y, -x)
+
+
+def rotate_world(universe, xy_rot, z_rot):
+    rotated = instantiate_universe()
+    for x in range(3):
+        for y in range(3):
+            for z in range(3):
+                cx, cy, cz = x - 1, y - 1, z - 1
+                rx, ry, rz = rotate_coord_xy(cx, cy, cz, xy_rot)
+                rx, ry, rz = rotate_coord_z(rx, ry, rz, z_rot)
+                rotated[rx + 1][ry + 1][rz + 1] = universe[x][y][z]
+    return rotated
+
+
+def universe_key(universe):
+    return tuple(
+        universe[x][y][z]
+        for z in range(3)
+        for y in range(3)
+        for x in range(3)
+    )
+
+
+def is_canonical(universe):
+    canonical_key = universe_key(universe)
+    for z_rot in range(6):
+        for xy_rot in range(4):
+            if z_rot == 0 and xy_rot == 0:
+                continue
+            rotated = rotate_world(universe, xy_rot, z_rot)
+            if universe_key(rotated) < canonical_key:
+                return False
+    return True
 
 
 def print_universe(universe):


### PR DESCRIPTION
This makes the Python and Go implementations filter out noncanonical solutions, i.e. solutions that are identical to other solutions except that the whole puzzle world is rotated.

The Rust implementation was already doing this.  With this change, all 3 implementations find the exact same set of 415 solutions.